### PR TITLE
Use AGPLv3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Please read and follow our [Code of Conduct](https://github.com/OpenBookOrg/www.
 
 #### License
 
-Every contribution accepted is licensed under [AGPL v3.0](http://www.gnu.org/licenses/agpl-3.0.html). 
+Every contribution accepted is licensed under [AGPL v3.0](http://www.gnu.org/licenses/agpl-3.0.html) or any later version. 
 You must be careful to not include any code that can not be licensed under this license.
 
 Please read carefully [our license](https://github.com/OpenBookOrg/www.open-book.org/blob/master/LICENSE.txt) and ask us if you have any questions.


### PR DESCRIPTION
It's important to specify that the license is AGPL version 3 or (at your option) any later version, which is recommended in the license itself. This way if a new version of the AGPL comes out, this code is still useful to projects using the theoretical AGPLv4 license.